### PR TITLE
v1: 다크모드 구현

### DIFF
--- a/components/dark-mode-toggle-button.js
+++ b/components/dark-mode-toggle-button.js
@@ -1,0 +1,43 @@
+import { useTheme } from 'next-themes'
+
+export default function DarkModeToggleButton() {
+    const { theme, setTheme } = useTheme()
+    return (
+        <>
+            <button className="
+                    inline-flex items-center 
+                    bg-gray-200 border-0 py-1 px-3 
+                    focus:outline-none 
+                    hover:bg-gray-100 rounded text-base mt-4 md:mt-0 
+                    hover:text-orange-500 
+                    dark:hover:bg-slate-700
+                    dark:hover:text-yellow-300
+                    dark:text-slate-400
+                    dark:bg-slate-600
+                "
+                type="button"
+                onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            >
+                {/* 라이드 모드 */}
+                <svg xmlns="http://www.w3.org/2000/svg" 
+                    viewBox="0 0 24 24" 
+                    fill="currentColor" 
+                    className="visible dark:invisible dark:h-0 dark:w-0 h-5 h-5"
+                >
+                    <path d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5H21a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM7.758 17.303a.75.75 0 0 0-1.061-1.06l-1.591 1.59a.75.75 0 0 0 1.06 1.061l1.591-1.59ZM6 12a.75.75 0 0 1-.75.75H3a.75.75 0 0 1 0-1.5h2.25A.75.75 0 0 1 6 12ZM6.697 7.757a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 0 0-1.061 1.06l1.59 1.591Z" />
+                </svg>
+
+
+                {/* 다크 모드 */}
+                <svg xmlns="http://www.w3.org/2000/svg" 
+                    viewBox="0 0 24 24" 
+                    fill="currentColor" 
+                    className="invisible dark:visible dark:h-5 dark:w-5 h-0 h-0"
+                >
+                    <path fillRule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clipRule="evenodd" />
+                </svg>
+
+            </button>
+        </>
+    );
+}

--- a/components/footer.js
+++ b/components/footer.js
@@ -3,13 +3,13 @@ import Link from "next/link";
 export default function Footer() {
     return (
         <>
-            <footer className="text-gray-600 body-font">
-                <div className="bg-gray-100">
+            <footer className="body-font">
+                <div>
                     <div className="container px-5 py-6 mx-auto flex items-center sm:flex-row flex-col">
                     <Link href="/">
                         <a className="flex title-font font-medium items-center md:justify-start justify-center text-gray-900">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" className="w-10 h-10 text-white p-2 bg-green-500 rounded-full">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" />
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" className="w-10 h-10 text-white p-2 bg-green-500 rounded-full">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" />
                         </svg>
                             <span className="ml-3 text-xl">김믿음 포트폴리오</span>
                         </a>
@@ -19,23 +19,23 @@ export default function Footer() {
                     </p>
                     <span className="inline-flex sm:ml-auto sm:mt-0 mt-4 justify-center sm:justify-start">
                         <a className="text-gray-500">
-                        <svg fill="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" className="w-5 h-5" viewBox="0 0 24 24">
+                        <svg fill="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-5 h-5" viewBox="0 0 24 24">
                             <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"></path>
                         </svg>
                         </a>
                         <a className="ml-3 text-gray-500">
-                        <svg fill="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" className="w-5 h-5" viewBox="0 0 24 24">
+                        <svg fill="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-5 h-5" viewBox="0 0 24 24">
                             <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"></path>
                         </svg>
                         </a>
                         <a className="ml-3 text-gray-500">
-                        <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" className="w-5 h-5" viewBox="0 0 24 24">
+                        <svg fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-5 h-5" viewBox="0 0 24 24">
                             <rect width="20" height="20" x="2" y="2" rx="5" ry="5"></rect>
                             <path d="M16 11.37A4 4 0 1112.63 8 4 4 0 0116 11.37zm1.5-4.87h.01"></path>
                         </svg>
                         </a>
                         <a className="ml-3 text-gray-500">
-                        <svg fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="0" className="w-5 h-5" viewBox="0 0 24 24">
+                        <svg fill="currentColor" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="0" className="w-5 h-5" viewBox="0 0 24 24">
                             <path stroke="none" d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-2-2 2 2 0 00-2 2v7h-4v-7a6 6 0 016-6zM2 9h4v12H2z"></path>
                             <circle cx="4" cy="4" r="2" stroke="none"></circle>
                         </svg>

--- a/components/header.js
+++ b/components/header.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import DarkModeToggleButton from './dark-mode-toggle-button';
 
 export default function Header() {
     return (
@@ -22,11 +23,8 @@ export default function Header() {
                         </Link>
                         <a href="https://open.kakao.com/o/sbDxLt9h" className="mr-5 hover:text-gray-900">연락하기</a>
                     </nav>
-                    <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0">Button
-                    <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" className="w-4 h-4 ml-1" viewBox="0 0 24 24">
-                        <path d="M5 12h14M12 5l7 7-7 7"></path>
-                    </svg>
-                    </button>
+                    {/* 다크모드 토글 버튼 작업 필요 */}
+                    <DarkModeToggleButton />
                 </div>
             </header>
         </>

--- a/components/home/main.js
+++ b/components/home/main.js
@@ -15,7 +15,7 @@ export default function Main() {
                 </p>
                 <div className="flex justify-center">
                     <Link href="/projects">
-                        <a className="inline-flex text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded text-lg">
+                        <a className="btn-project">
                             프로젝트 보러가기
                         </a>
                     </Link>

--- a/components/layout.js
+++ b/components/layout.js
@@ -3,10 +3,10 @@ import Footer from './footer';
 
 export default function Layout({ children }) {
     return (
-        <>
+        <div className="bg-primary">
             <Header />
             <div>{children}</div>
             <Footer />
-        </>
+        </div>
     );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "12.1.6",
+        "next-themes": "^0.4.6",
         "react": "18.1.0",
         "react-dom": "18.1.0",
         "react-lottie-player": "^2.1.0"
@@ -3333,6 +3334,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "12.1.6",
+    "next-themes": "^0.4.6",
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-lottie-player": "^2.1.0"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,13 @@
 import '../styles/globals.css'
+import { ThemeProvider } from 'next-themes'
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <ThemeProvider attribute="class">
+      <Component {...pageProps} />
+    </ThemeProvider>
+  )
+  
 }
 
 export default MyApp

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.bg-primary {
+  @apply bg-white dark:bg-slate-800
+}
+.btn-project {
+  @apply inline-flex text-white dark:text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded text-lg
+  
+}
+
+h1, h2, h3, h4, h5, h6 {
+    @apply text-slate-900 dark:text-white
+}
+
+footer {
+    @apply text-gray-600 dark:text-white
+    bg-gray-100 dark:bg-slate-600/20
+}
+
+a {
+    @apply text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-50
+}
+
+p {
+    @apply text-slate-500 dark:text-slate-400
+}


### PR DESCRIPTION
- close #13
- globals.css적용
- <path stroke-linecap="round" stroke-linejoin="round"
- -> 버전이 높아지면서 오류가 수정된거 같음(stroke-linecap으로도 적용가능)
- 테스트 완료
- 참고(nextjs 다크모드 라이브러리): https://github.com/pacocoursey/next-themes
- 참고(아이콘): https://heroicons.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다크 모드 토글 기능을 추가하여 사용자가 라이트/다크 테마 간 전환 가능

* **스타일**
  * 전체 애플리케이션에 다크 모드 테마 지원 구현
  * 컴포넌트 스타일링 및 레이아웃 최적화

* **의존성**
  * next-themes 라이브러리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->